### PR TITLE
Options and ring update

### DIFF
--- a/worlds/tloz_ooa/Options.py
+++ b/worlds/tloz_ooa/Options.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from Options import Choice, DeathLink, DefaultOnToggle, PerGameCommonOptions, Range, Toggle, StartInventoryPool
+from Options import Choice, DeathLink, DefaultOnToggle, PerGameCommonOptions, Range, Toggle, StartInventoryPool, ItemSet
+
+from worlds.tloz_ooa.data.Items import ITEMS_DATA
 
 
 class OracleOfAgesGoal(Choice):
@@ -145,18 +147,25 @@ class OracleOfAgesSlateShuffle(Toggle):
     display_name = "Slates Outside Dungeon 8"
 
 
-class OracleOfAgesRingQuality(Choice):
+class OracleOfSeasonsRequiredRings(ItemSet):
     """
-    Defines the quality of the rings that will be shuffled in your seed:
-    - Any: any ring can potentially be shuffled (including literally useless ones)
-    - Only Useful: only useful rings will be shuffled
+    Forces a specified set of rings to appear somewhere in the seed.
+    Adding too many rings to this list can cause generation failures.
+    List of ring names can be found here: https://zeldawiki.wiki/wiki/Magic_Ring
     """
-    display_name = "Rings Quality"
+    display_name = "Required Rings"
+    valid_keys = {name for name, idata in ITEMS_DATA.items() if "ring" in idata}
 
-    option_any = 0
-    option_only_useful = 1
 
-    default = 1
+class OracleOfSeasonsExcludedRings(ItemSet):
+    """
+    Forces a specified set of rings to not appear in the seed.
+    List of ring names can be found here: https://zeldawiki.wiki/wiki/Magic_Ring
+    """
+    display_name = "Excluded Rings"
+    default = sorted({name for name, idata in ITEMS_DATA.items() if "ring" in idata and idata["ring"] == "useless"})
+    valid_keys = {name for name, idata in ITEMS_DATA.items() if "ring" in idata}
+
 
 class OracleOfAgesPricesFactor(Range):
     """
@@ -222,9 +231,9 @@ class OracleOfAgesOptions(PerGameCommonOptions):
     keysanity_boss_keys: OracleOfAgesBossKeyShuffle
     keysanity_maps_compasses: OracleOfAgesMapCompassShuffle
     keysanity_slates: OracleOfAgesSlateShuffle
-    ring_quality: OracleOfAgesRingQuality
+    required_rings: OracleOfSeasonsRequiredRings
+    excluded_rings: OracleOfSeasonsExcludedRings
     shop_prices_factor: OracleOfAgesPricesFactor
     advance_shop: OracleOfAgesAdvanceShop
-    warp_to_start: OracleOfAgesWarpToStart
     combat_difficulty: OracleOfAgesCombatDifficulty
     death_link: DeathLink

--- a/worlds/tloz_ooa/PatchWriter.py
+++ b/worlds/tloz_ooa/PatchWriter.py
@@ -25,7 +25,7 @@ def ooa_create_appp_patch(world: "OracleOfAgesWorld") -> OoAProcedurePatch:
             "start_inventory_from_pool", "goal", "logic_difficulty", "required_essences",
             "required_slates", "animal_companion", "default_seed", "shuffle_dungeons", "master_keys",
             "keysanity_small_keys", "keysanity_boss_keys", "keysanity_maps_compasses", "keysanity_slates",
-            "ring_quality", "shop_prices_factor", "advance_shop", "warp_to_start",
+            "required_rings", "excluded_rings", "shop_prices_factor", "advance_shop",
             "combat_difficulty", "death_link"
         ]),
         "dungeon_entrances": {a.replace(" entrance", ""): b.replace("enter ", "")

--- a/worlds/tloz_ooa/__init__.py
+++ b/worlds/tloz_ooa/__init__.py
@@ -5,7 +5,7 @@ import settings
 
 from BaseClasses import Tutorial, Region, Location, LocationProgressType
 from Fill import fill_restrictive, FillError
-from Options import Accessibility
+from Options import Accessibility, OptionError
 from worlds.AutoWorld import WebWorld, World
 from typing import Any, Set, List, Dict, Optional, Tuple, ClassVar, TextIO, Union
 from .Data import *
@@ -120,7 +120,7 @@ class OracleOfAgesWorld(World):
         # TODO MOAR DATA ?
         options = ["goal", "death_link",
                    # Logic-impacting options
-                   "logic_difficulty", "warp_to_start",
+                   "logic_difficulty",
                    "shuffle_dungeons",
                    "default_seed",
                    # Locations
@@ -140,6 +140,10 @@ class OracleOfAgesWorld(World):
         return slot_data
 
     def generate_early(self):
+        conflicting_rings = self.options.required_rings.value & self.options.excluded_rings.value
+        if len(conflicting_rings) > 0:
+            raise OptionError("Required Rings and Excluded Rings contain the same element(s)", conflicting_rings)
+        
         self.restrict_non_local_items()
 
         if self.options.shuffle_dungeons == "shuffle":
@@ -266,12 +270,25 @@ class OracleOfAgesWorld(World):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("_beaten_game", self.player)
 
     def create_item(self, name: str) -> Item:
+        if name.endswith("!PROG"):
+            # If item name has a "!PROG" suffix, force it to be progression. This is typically used to create the right
+            # amount of progression rupees while keeping them a filler item as default
+            name = name.removesuffix("!PROG")
+            classification = ItemClassification.progression_skip_balancing
+        elif name.endswith("!USEFUL"):
+            # Same for above but with useful. This is typically used for Required Rings,
+            # as we don't want those locked in a barren dungeon
+            name = name.removesuffix("!USEFUL")
+            classification = ITEMS_DATA[name]["classification"]
+            if classification == ItemClassification.filler:
+                classification = ItemClassification.useful
+        else:
+            classification = ITEMS_DATA[name]["classification"]
         ap_code = self.item_name_to_id[name]
-        classification = ITEMS_DATA[name]["classification"]
 
         # A few items become progression only in hard logic
-        progression_items_in_hard_logic = ["Expert's Ring", "Fist Ring", "Swimmer's Ring"]
-        if self.options.logic_difficulty == "hard" and name in progression_items_in_hard_logic:
+        progression_items_in_medium_logic = ["Expert's Ring", "Fist Ring", "Swimmer's Ring", "Toss Ring", "Enery Ring"]
+        if self.options.logic_difficulty == "medium" and name in progression_items_in_medium_logic:
             classification = ItemClassification.progression
 
         return Item(name, classification, ap_code, self.player)
@@ -316,6 +333,19 @@ class OracleOfAgesWorld(World):
         if self.options.master_keys != OracleOfAgesMasterKeys.option_disabled:
             for small_key_name in ITEM_GROUPS["Master Keys"]:
                 item_pool_dict[small_key_name] = 1
+                filler_item_count -= 1
+
+        # Add the required rings
+        ring_copy = sorted(self.options.required_rings.value.copy())
+        for _ in range(len(ring_copy)):
+            ring_name = f"{ring_copy.pop()}!USEFUL"
+            item_pool_dict[ring_name] = item_pool_dict.get(ring_name, 0) + 1
+
+            if item_pool_dict["Random Ring"] > 0:
+                # Take from set ring pool first
+                item_pool_dict["Random Ring"] -= 1
+            else:
+                # Take from filler after
                 filler_item_count -= 1
 
         # Add as many filler items as required
@@ -363,16 +393,16 @@ class OracleOfAgesWorld(World):
                     self.multiworld.itempool.append(self.create_item(item_name))        
 
     def create_rings(self, amount):
-        # Get a subset of as many rings as needed, with a potential filter on quality depending on chosen options
-        ring_names = [name for name, idata in ITEMS_DATA.items() if "ring" in idata and idata["ring"] is True]
-        if self.options.ring_quality == "only_useful":
-            forbidden_classes = [ItemClassification.filler, ItemClassification.trap]
-            ring_names = [name for name in ring_names if ITEMS_DATA[name]["classification"] not in forbidden_classes]
+        # Get a subset of as many rings as needed
+        ring_names = [name for name, idata in ITEMS_DATA.items() if "ring" in idata]
+        # Remove excluded rings, and required rings because they'll be added later anyway
+        ring_names = [name for name in ring_names if name not in self.options.required_rings.value and name not in self.options.excluded_rings.value]
 
         self.random.shuffle(ring_names)
         del ring_names[amount:]
         for ring_name in ring_names:
             self.multiworld.itempool.append(self.create_item(ring_name))
+        self.random_rings_pool = ring_names
 
     def get_pre_fill_items(self):
         return self.pre_fill_items

--- a/worlds/tloz_ooa/__init__.py
+++ b/worlds/tloz_ooa/__init__.py
@@ -287,7 +287,7 @@ class OracleOfAgesWorld(World):
         ap_code = self.item_name_to_id[name]
 
         # A few items become progression only in hard logic
-        progression_items_in_medium_logic = ["Expert's Ring", "Fist Ring", "Swimmer's Ring", "Toss Ring", "Enery Ring"]
+        progression_items_in_medium_logic = ["Expert's Ring", "Fist Ring", "Toss Ring", "Enery Ring"]
         if self.options.logic_difficulty == "medium" and name in progression_items_in_medium_logic:
             classification = ItemClassification.progression
 
@@ -296,6 +296,7 @@ class OracleOfAgesWorld(World):
     def build_item_pool_dict(self):
         item_pool_dict = {}
         filler_item_count = 0
+        remaining_rings = len({name for name, idata in ITEMS_DATA.items() if "ring" in idata}) - len(self.options.excluded_rings.value)
         for loc_name, loc_data in LOCATIONS_DATA.items():
 
             if "vanilla_item" not in loc_data:
@@ -325,7 +326,12 @@ class OracleOfAgesWorld(World):
 
             item_name = loc_data['vanilla_item']
             if "Ring" in item_name:
-                item_name = "Random Ring"
+                if remaining_rings > 0:
+                    item_name = "Random Ring"
+                    remaining_rings -= 1
+                else:
+                    filler_item_count += 1
+                    continue
 
             item_pool_dict[item_name] = item_pool_dict.get(item_name, 0) + 1
 
@@ -376,8 +382,9 @@ class OracleOfAgesWorld(World):
         item_pool_dict = self.build_item_pool_dict()
         
         # Create items following the dictionary that was previously constructed
-        self.create_rings(item_pool_dict["Random Ring"])
-        del item_pool_dict["Random Ring"]
+        if (item_pool_dict.get("Random Ring")):
+            self.create_rings(item_pool_dict["Random Ring"])
+            del item_pool_dict["Random Ring"]
 
         for item_name, quantity in item_pool_dict.items():
             for i in range(quantity):

--- a/worlds/tloz_ooa/data/Items.py
+++ b/worlds/tloz_ooa/data/Items.py
@@ -563,385 +563,385 @@ ITEMS_DATA = {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x04,
-        'ring': True
+        'ring': 'useless'
     },
     "Power Ring L-1": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x05,
-        'ring': True
+        'ring': 'good'
     },
     "Power Ring L-2": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x06,
-        'ring': True
+        'ring': 'good'
     },
     "Power Ring L-3": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x07,
-        'ring': True
+        'ring': 'good'
     },
     "Armor Ring L-1": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x08,
-        'ring': True
+        'ring': 'good'
     },
     "Armor Ring L-2": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x09,
-        'ring': True
+        'ring': 'good'
     },
     "Armor Ring L-3": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x0a,
-        'ring': True
+        'ring': 'good'
     },
     "Red Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x0b,
-        'ring': True
+        'ring': 'good'
     },
     "Blue Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x0c,
-        'ring': True
+        'ring': 'good'
     },
     "Green Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x0d,
-        'ring': True
+        'ring': 'good'
     },
     "Cursed Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x0e,
-        'ring': True
+        'ring': 'useless'
     },
     "Expert's Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x0f,
-        'ring': True
+        'ring': 'good'
     },
     "Blast Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x10,
-        'ring': True
+        'ring': 'good'
     },
     "Rang Ring L-1": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x11,
-        'ring': True
+        'ring': 'good'
     },
     "GBA Time Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x12,
-        'ring': True
+        'ring': 'useless'
     },
     "Maple's Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x13,
-        'ring': True
+        'ring': 'good'
     },
     "Steadfast Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x14,
-        'ring': True
+        'ring': 'good'
     },
     "Pegasus Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x15,
-        'ring': True
+        'ring': 'good'
     },
     "Toss Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x16,
-        'ring': True
+        'ring': 'good'
     },
     "Heart Ring L-1": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x17,
-        'ring': True
+        'ring': 'good'
     },
     "Heart Ring L-2": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x18,
-        'ring': True
+        'ring': 'good'
     },
     "Swimmer's Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x19,
-        'ring': True
+        'ring': 'good'
     },
     "Charge Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x1a,
-        'ring': True
+        'ring': 'good'
     },
     "Light Ring L-1": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x1b,
-        'ring': True
+        'ring': 'good'
     },
     "Light Ring L-2": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x1c,
-        'ring': True
+        'ring': 'good'
     },
     "Bomber's Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x1d,
-        'ring': True
+        'ring': 'good'
     },
     "Green Luck Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x1e,
-        'ring': True
+        'ring': 'good'
     },
     "Blue Luck Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x1f,
-        'ring': True
+        'ring': 'good'
     },
     "Gold Luck Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x20,
-        'ring': True
+        'ring': 'good'
     },
     "Red Luck Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x21,
-        'ring': True
+        'ring': 'good'
     },
     "Green Holy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x22,
-        'ring': True
+        'ring': 'good'
     },
     "Blue Holy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x23,
-        'ring': True
+        'ring': 'good'
     },
     "Red Holy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x24,
-        'ring': True
+        'ring': 'good'
     },
     "Snowshoe Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x25,
-        'ring': True
+        'ring': 'good'
     },
     "Roc's Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x26,
-        'ring': True
+        'ring': 'good'
     },
     "Quicksand Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x27,
-        'ring': True
+        'ring': 'good'
     },
     "Red Joy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x28,
-        'ring': True
+        'ring': 'good'
     },
     "Blue Joy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x29,
-        'ring': True
+        'ring': 'good'
     },
     "Gold Joy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x2a,
-        'ring': True
+        'ring': 'good'
     },
     "Green Joy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x2b,
-        'ring': True
+        'ring': 'good'
     },
     "Discovery Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x2c,
-        'ring': True
+        'ring': 'good'
     },
     "Rang Ring L-2": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x2d,
-        'ring': True
+        'ring': 'good'
     },
     "Octo Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x2e,
-        'ring': True
+        'ring': 'useless'
     },
     "Moblin Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x2f,
-        'ring': True
+        'ring': 'useless'
     },
     "Like Like Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x30,
-        'ring': True
+        'ring': 'useless'
     },
     "Subrosian Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x31,
-        'ring': True
+        'ring': 'useless'
     },
     "First Gen Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x32,
-        'ring': True
+        'ring': 'useless'
     },
     "Spin Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x33,
-        'ring': True
+        'ring': 'good'
     },
     "Bombproof Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x34,
-        'ring': True
+        'ring': 'good'
     },
     "Energy Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x35,
-        'ring': True
+        'ring': 'good'
     },
-    "Double Edge Ring": {
-        'classification': ItemClassification.useful,
+    "Dbl. Edge Ring": {
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x36,
-        'ring': True
+        'ring': 'good'
     },
     "GBA Nature Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x37,
-        'ring': True
+        'ring': 'useless'
     },
     "Slayer's Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x38,
-        'ring': True
+        'ring': 'useless'
     },
     "Rupee Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x39,
-        'ring': True
+        'ring': 'useless'
     },
     "Victory Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x3a,
-        'ring': True
+        'ring': 'useless'
     },
     "Sign Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x3b,
-        'ring': True
+        'ring': 'useless'
     },
     "100th Ring": {
         'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x3c,
-        'ring': True
+        'ring': 'useless'
     },
     "Whisp Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x3d,
-        'ring': True
+        'ring': 'good'
     },
     "Gasha Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x3e,
-        'ring': True
+        'ring': 'good'
     },
     "Peace Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x3f,
-        'ring': True
+        'ring': 'good'
     },
     "Zora Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x40,
-        'ring': True
+        'ring': 'good'
     },
     "Fist Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x41,
-        'ring': True
+        'ring': 'good'
     },
     "Whimsical Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x42,
-        'ring': True
+        'ring': 'good'
     },
     "Protection Ring": {
-        'classification': ItemClassification.useful,
+        'classification': ItemClassification.filler,
         'id': 0x2d,
         'subid': 0x43,
-        'ring': True
+        'ring': 'good'
     },
 
     "Eternal Spirit": {

--- a/worlds/tloz_ooa/data/logic/DungeonsLogic.py
+++ b/worlds/tloz_ooa/data/logic/DungeonsLogic.py
@@ -218,15 +218,10 @@ def make_d3_logic(player: int):
         ["d3 pitfall", "d3 crossing bridge room 1", True, lambda state: any([
             ooa_has_seedshooter(state, player),
             ooa_can_jump_3_wide_pit(state, player, False),
+            ooa_can_toss_ring(state, player),
             all([
                 ooa_option_hard_logic(state, player),
-                any([
-                    ooa_has_boomerang(state, player),
-                    all([
-                        ooa_has_bracelet(state, player),
-                        state.has("Toss Ring", player)
-                    ]),
-                ]),
+                ooa_has_boomerang(state, player)
             ])
         ])],
         ["d3 crossing bridge room 1", "d3 between two bridge room", True, lambda state: ooa_has_small_keys(state, player, 3, 4)],
@@ -462,14 +457,10 @@ def make_d5_logic(player: int):
         ["d5 switch A", "d5 eyes chest", False, lambda state: any([
             ooa_has_seedshooter(state, player),
             all([
-                ooa_option_hard_logic(state, player),
                 ooa_can_use_pegasus_seeds(state, player),
                 ooa_has_feather(state, player),
                 ooa_can_use_mystery_seeds(state, player),
-                any([
-                    ooa_has_bracelet(state, player) and state.has("Toss Ring", player),
-                    ooa_has_cane(state, player),
-                ])
+                ooa_can_toss_ring(state, player)
             ])
         ])],
         ["d5 switch A", "d5 two-statue puzzle", False, lambda state: all([
@@ -688,7 +679,7 @@ def make_d6present_logic(player: int):
             any([
                 ooa_has_sword(state, player),
                 state.has("Expert's Ring", player),
-                ooa_option_hard_logic(state, player) # for switch hook kill (?)
+                ooa_option_medium_logic(state, player) # for switch hook kill (?)
             ]),
             ooa_has_small_keys(state, player, 6, 3),
             ooa_has_switch_hook(state, player)

--- a/worlds/tloz_ooa/data/logic/LogicPredicates.py
+++ b/worlds/tloz_ooa/data/logic/LogicPredicates.py
@@ -123,10 +123,6 @@ def ooa_option_hard_logic(state: CollectionState, player: int):
     return state.multiworld.worlds[player].options.logic_difficulty == "hard"
 
 
-def ooa_option_allow_warp_to_start(state: CollectionState, player: int):
-    return state.multiworld.worlds[player].options.warp_to_start.value
-
-
 def ooa_is_companion_ricky(state: CollectionState, player: int):
     return state.multiworld.worlds[player].options.animal_companion == "ricky"
 
@@ -219,7 +215,7 @@ def ooa_can_trigger_far_switch(state: CollectionState, player: int):
         ooa_has_seedshooter(state, player),
         ooa_has_switch_hook(state, player),
         all([
-            ooa_option_hard_logic(state, player),
+            ooa_option_medium_logic(state, player),
             ooa_has_sword(state, player, False),
             state.has("Energy Ring", player)
         ])
@@ -432,13 +428,6 @@ def ooa_can_use_gale_seeds_offensively(state: CollectionState, player: int, rang
     ])
 
 
-def ooa_can_warp(state: CollectionState, player: int):
-    # Never expect points of no return / risky checks for casual logic
-    if not ooa_option_medium_logic(state, player):
-        return False
-    return ooa_can_warp_using_gale_seeds(state, player) or ooa_option_allow_warp_to_start(state, player)
-
-
 def ooa_can_use_mystery_seeds(state: CollectionState, player: int):
     return all([
         ooa_can_use_seeds(state, player),
@@ -513,7 +502,7 @@ def ooa_can_break_crystal(state: CollectionState, player: int):
         ooa_has_bombs(state, player),
         ooa_has_bracelet(state, player),
         all([
-            ooa_option_hard_logic(state, player),
+            ooa_option_medium_logic(state, player),
             state.has("Expert's Ring", player)
         ])
     ])
@@ -698,7 +687,7 @@ def ooa_can_kill_armos(state: CollectionState, player: int, ranged: bool = False
 
 def ooa_can_punch(state: CollectionState, player: int):
     return all([
-        ooa_option_hard_logic(state, player),
+        ooa_option_medium_logic(state, player),
         any([
             state.has("Fist Ring", player),
             state.has("Expert's Ring", player)
@@ -772,6 +761,13 @@ def ooa_can_remove_dirt(state: CollectionState, player: int, can_summon_companio
 
 def ooa_can_meet_maple(state: CollectionState, player: int):
     return ooa_can_kill_normal_enemy(state, player)
+
+def ooa_can_toss_ring(state: CollectionState, player: int):
+    return all([
+        ooa_option_medium_logic(state, player),
+        ooa_has_bracelet(state, player),
+        state.has("Toss Ring", player)
+    ])
 
 # Self-locking items helper predicates ##########################################
 

--- a/worlds/tloz_ooa/data/logic/OverworldLogic.py
+++ b/worlds/tloz_ooa/data/logic/OverworldLogic.py
@@ -207,7 +207,7 @@ def make_overworld_logic(player: int):
             ])
         ])],
         ["deku forest", "deku forest tree", False, lambda state: all([
-            ooa_can_harvest_tree(state, player, False),                    
+            ooa_can_harvest_tree(state, player, False),
             any([
                 ooa_can_jump_1_wide_pit(state, player, False),
                 ooa_has_switch_hook(state, player),
@@ -255,11 +255,7 @@ def make_overworld_logic(player: int):
             ooa_can_go_back_to_present(state, player),
             all([
                 ooa_has_shovel(state, player),
-                ooa_can_open_portal(state, player),
-                any([
-                    ooa_can_warp(state,player),
-                    ooa_has_bracelet(state,player)
-                ])
+                ooa_can_open_portal(state, player)
             ])
         ])],
         ["crescent present west", "d3 entrance", False, None],
@@ -328,10 +324,7 @@ def make_overworld_logic(player: int):
             state.has("Tuni Nut", player),
             any([
                 ooa_can_go_back_to_present(state, player),
-                all([
-                    ooa_can_open_portal(state, player),
-                    ooa_can_warp(state, player),
-                ])
+                ooa_can_open_portal(state, player)
             ])
         ])],
 

--- a/worlds/tloz_ooa/patching/Constants.py
+++ b/worlds/tloz_ooa/patching/Constants.py
@@ -432,6 +432,7 @@ ASM_FILES = [
     "asm/combat_difficulty.yaml",
     "asm/tokay_market.yaml",
     "asm/compass_chimes.yaml",
+    "asm/conditional/warp_to_start.yaml"
 ]
 
 RUPEE_VALUES = {

--- a/worlds/tloz_ooa/patching/Constants.py
+++ b/worlds/tloz_ooa/patching/Constants.py
@@ -432,7 +432,7 @@ ASM_FILES = [
     "asm/combat_difficulty.yaml",
     "asm/tokay_market.yaml",
     "asm/compass_chimes.yaml",
-    "asm/conditional/warp_to_start.yaml"
+    "asm/warp_to_start.yaml"
 ]
 
 RUPEE_VALUES = {

--- a/worlds/tloz_ooa/patching/Functions.py
+++ b/worlds/tloz_ooa/patching/Functions.py
@@ -58,8 +58,6 @@ def get_asm_files(patch_data):
         asm_files.append("asm/conditional/skip_joke.yaml")
     if get_settings()["tloz_ooa_options"]["qol_mermaid_suit"]:
         asm_files.append("asm/conditional/qol_mermaid_suit.yaml")
-    if patch_data["options"]["warp_to_start"]:
-        asm_files.append("asm/conditional/warp_to_start.yaml")
     if patch_data["options"]["goal"] == OracleOfAgesGoal.option_beat_ganon:
         asm_files.append("asm/conditional/ganon_goal.yaml")
     return asm_files
@@ -97,7 +95,7 @@ def define_option_constants(assembler: Z80Assembler, patch_data):
     assembler.define_byte("option.defaultSeedType", 0x20 + patch_data["options"]["default_seed"])
     assembler.define_byte("option.receivedDamageModifier", options["combat_difficulty"])
     assembler.define_byte("option.openAdvanceShop", options["advance_shop"])
-    assembler.define_byte("option.warpToStart", options["warp_to_start"])
+    assembler.define_byte("option.warpToStart", True)
 
     assembler.define_byte("option.requiredEssences", options["required_essences"])
     assembler.define_byte("option.required_slates", options["required_slates"])

--- a/worlds/tloz_ooa/patching/Functions.py
+++ b/worlds/tloz_ooa/patching/Functions.py
@@ -95,7 +95,6 @@ def define_option_constants(assembler: Z80Assembler, patch_data):
     assembler.define_byte("option.defaultSeedType", 0x20 + patch_data["options"]["default_seed"])
     assembler.define_byte("option.receivedDamageModifier", options["combat_difficulty"])
     assembler.define_byte("option.openAdvanceShop", options["advance_shop"])
-    assembler.define_byte("option.warpToStart", True)
 
     assembler.define_byte("option.requiredEssences", options["required_essences"])
     assembler.define_byte("option.required_slates", options["required_slates"])

--- a/worlds/tloz_ooa/patching/asm/warp_to_start.yaml
+++ b/worlds/tloz_ooa/patching/asm/warp_to_start.yaml
@@ -12,12 +12,8 @@
 #    jp checkTreeVisited
 #02/609b/: call checkCursorVisited
 
-# warp to horon village tree if holding start when opening the map screen.
+# warp to start location if holding start when opening the map screen.
 02//checkWarpToStart: |
-    ld a,option.warpToStart
-    or a
-    jr z,@done
-    
     ld a,(wKeysPressed)
     and BTN_B | BTN_A
     cp BTN_B | BTN_A


### PR DESCRIPTION
## What is this fixing or adding?
- Remove Warp to Start option and force it always on
- Replace Ring Quality option with Required/Excluded Rings options. Default for Excluded is the same list that would be excluded with the Ring Quality option
- Logic-relevant rings (Fist, Expert, Energy, Toss) moved into medium logic

## How was this tested?
Test gens, loading game and trying warp to start