### PR TITLE
Fix ACE vulnerability

### DIFF
--- a/worlds/tloz_ooa/patching/ProcedurePatch.py
+++ b/worlds/tloz_ooa/patching/ProcedurePatch.py
@@ -23,7 +23,7 @@ class OoAPatchExtensions(APPatchExtension):
     @staticmethod
     def apply_patches(caller: APProcedurePatch, rom: bytes, patch_file: str) -> bytes:
         rom_data = RomData(rom)
-        patch_data = yaml.load(caller.get_file(patch_file).decode("utf-8"), yaml.Loader)
+        patch_data = yaml.safe_load(caller.get_file(patch_file).decode("utf-8"))
 
         if not (patch_data["version"] in RETRO_COMPAT_VERSION):
             raise Exception(f"Invalid version: this seed was generated on v{patch_data['version']}, "


### PR DESCRIPTION
Eijebong reminded me about this issue, you can replace the content of a patch.dat by `!!python/object/new:os.system [echo hello]` and notice a print of "hello" in the console currently