### PR TITLE
Fix piratian captain logic requirements

### DIFF
--- a/worlds/tloz_ooa/data/logic/OverworldLogic.py
+++ b/worlds/tloz_ooa/data/logic/OverworldLogic.py
@@ -573,7 +573,15 @@ def make_overworld_logic(player: int):
         
         # SEA OF NO RETURN
         #######################################
-        ["lynna city", "piratian captain", False, lambda state: all([
+       
+        # This would have been for the present version of the sea of storms cave. But since you are focusing on the past version of the sea of storms underwater cave right now, you would actually need to be able to travel to the past, 
+        # ALONG WITH having a zora's scale and a mermaid suit in order to claim the check. That's why I am changing the logic requirement on your sea of storms piratian captian check from needing lynna city to lynna village instead.
+        # ["lynna city", "piratian captain present", False, lambda state: all([
+        #    ooa_can_dive(state, player),
+        #    state.has("Zora Scale", player),
+        # ])],
+        # ["piratian captain", "sea of storms present", False, None],
+         ["lynna village", "piratian captain", False, lambda state: all([
             ooa_can_dive(state, player),
             state.has("Zora Scale", player),
         ])],

--- a/worlds/tloz_ooa/data/logic/OverworldLogic.py
+++ b/worlds/tloz_ooa/data/logic/OverworldLogic.py
@@ -580,7 +580,7 @@ def make_overworld_logic(player: int):
         #    ooa_can_dive(state, player),
         #    state.has("Zora Scale", player),
         # ])],
-        # ["piratian captain", "sea of storms present", False, None],
+        # ["piratian captain present", "sea of storms present", False, None],
          ["lynna village", "piratian captain", False, lambda state: all([
             ooa_can_dive(state, player),
             state.has("Zora Scale", player),


### PR DESCRIPTION
Right now, you have lynna city put in as one of the logical requirements for claiming the check which makes no sense because with your setup, you would actually need to travel to the past along with you having a mermaid suit and a zora's scale to claim the check, along with it's underwater cave as well. Your previous setup can actually be used to implement the present version of the check since there is that check normally in the linked game. Not sure how this bug was discovered sooner but I hope that you are able to merge this pull request.
